### PR TITLE
Fix TOC handling in epub generator

### DIFF
--- a/epub/epub_generator.py
+++ b/epub/epub_generator.py
@@ -1,14 +1,17 @@
 from ebooklib import epub
 import os
 
-def create_epub(title, author, chapters, output_dir, epub_filename, cover_image, toc):
+def create_epub(title, author, chapters, output_dir, epub_filename, cover_image, toc=None):
     book = epub.EpubBook()
     book.set_title(title)
     book.set_language('en')
     book.add_author(author)
 
-    # Define the TOC
-    book.toc = tuple(epub.Link(chapter[1], chapter[0], chapter[0]) for chapter in chapters)
+    # Define the TOC ensuring filenames match the added chapters
+    if toc is None:
+        toc = [epub.Link(f'chap_{i+1}.xhtml', chapter_title, chapter_title)
+               for i, (chapter_title, _) in enumerate(chapters)]
+    book.toc = tuple(toc)
 
     # Add chapters to the book
     for i, (chapter_title, content) in enumerate(chapters):

--- a/tests/test_epub_generator.py
+++ b/tests/test_epub_generator.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import tempfile
+from ebooklib import epub
 from epub.epub_generator import create_epub
 
 class TestEPUBGenerator(unittest.TestCase):
@@ -8,9 +10,21 @@ class TestEPUBGenerator(unittest.TestCase):
             ("Chapter 1", "This is the content of chapter 1."),
             ("Chapter 2", "This is the content of chapter 2.")
         ]
-        create_epub("Test Novel", chapters)
-        self.assertTrue(os.path.exists("Test Novel.epub"))
-        os.remove("Test Novel.epub")
+        toc = [epub.Link(f'chap_{i+1}.xhtml', title, title)
+               for i, (title, _) in enumerate(chapters)]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            create_epub(
+                "Test Novel",
+                "Author",
+                chapters,
+                tmpdir,
+                "Test_Novel.epub",
+                None,
+                toc,
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(tmpdir, "Test_Novel.epub"))
+            )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- keep chapter filenames consistent in `create_epub`
- use provided TOC or build one with matching filenames
- update unit test to call new signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ebooklib and scraper, SyntaxError in test_translator)*

------
https://chatgpt.com/codex/tasks/task_e_684a4bc6f7b0832bbcc6663dd51ee853